### PR TITLE
Add Helikon boot node

### DIFF
--- a/polimec-raw-chain-spec.json
+++ b/polimec-raw-chain-spec.json
@@ -4,7 +4,9 @@
   "chainType": "Live",
   "bootNodes": [
     "/ip4/141.95.47.7/tcp/30333/p2p/12D3KooWSCjh8tN5yzmLgxWR4kauD5NmCmP2ymc3D5WubvMETg6b",
-    "/ip4/57.128.20.108/tcp/30333/p2p/12D3KooWEe7ps1v1mfhjMNaSaukgxsFVL6cqeEQudqZ5t3oQiXNL"
+    "/ip4/57.128.20.108/tcp/30333/p2p/12D3KooWEe7ps1v1mfhjMNaSaukgxsFVL6cqeEQudqZ5t3oQiXNL",
+    "/dns4/boot.helikon.io/tcp/15320/p2p/12D3KooWT2y3C2nzKGJV1Jss3EyCcwGWeroDFfFdJ5CUVz3iQGJD",
+    "/dns4/boot.helikon.io/tcp/15324/wss/p2p/12D3KooWT2y3C2nzKGJV1Jss3EyCcwGWeroDFfFdJ5CUVz3iQGJD"
   ],
   "telemetryEndpoints": null,
   "protocolId": "polimec",


### PR DESCRIPTION
This PR adds the Helikon boot node into the chain spec.

To test the boot node in isolation:

```
./polimec-parachain-node --chain ./polimec-raw-chain-spec.json --tmp --reserved-only --reserved-nodes "/dns4/boot.helikon.io/tcp/15320/p2p/12D3KooWT2y3C2nzKGJV1Jss3EyCcwGWeroDFfFdJ5CUVz3iQGJD"
./polimec-parachain-node --chain ./polimec-raw-chain-spec.json --tmp --reserved-only --reserved-nodes "/dns4/boot.helikon.io/tcp/15324/wss/p2p/12D3KooWT2y3C2nzKGJV1Jss3EyCcwGWeroDFfFdJ5CUVz3iQGJD"
```

Thanks!